### PR TITLE
Screenshot parameter doesn't work for option 2

### DIFF
--- a/src/main/java/org/cerberus/launchcampaign/executecampaign/ExecuteCampaignDto.java
+++ b/src/main/java/org/cerberus/launchcampaign/executecampaign/ExecuteCampaignDto.java
@@ -128,7 +128,7 @@ public class ExecuteCampaignDto {
 		return "";
 	}
 	private String check0or1or2(int parameter, String parameterName) {
-	    if(parameter != 0 && parameter != 1) {
+	    if(parameter != 0 && parameter != 1 && parameter != 2) {
 	        return parameterName + " must be 0, 1 or 2 but is " + parameter + ", ";
 	    }
 	    return "";


### PR DESCRIPTION
I got this error if I specified 2 as screenshot parameter : 

[ERROR] [2017-12-06 02:48:20.4820] error for campaign  MyAccount : 
java.lang.IllegalArgumentException: screenshot must be 0, 1 or 2 but is 2, 
	at org.cerberus.launchcampaign.executecampaign.ExecuteCampaign.execute(ExecuteCampaign.java:55)
	at org.cerberus.jenkinsci.plugins.executecerberustest.ExecuteCerberusCampaign.perform(ExecuteCerberusCampaign.java:137)
	at hudson.tasks.BuildStepCompatibilityLayer.perform(BuildStepCompatibilityLayer.java:74)
	at hudson.tasks.BuildStepMonitor$1.perform(BuildStepMonitor.java:20)